### PR TITLE
Add transitive metadata to custom array abstract

### DIFF
--- a/src/sinker/Array.hx
+++ b/src/sinker/Array.hx
@@ -11,6 +11,7 @@ import sinker.errors.ArrayErrors;
 	- Uses `unsafeGet()`/`unsafeSet()` on cpp target.
 	- Does boundary check `#if sinker_debug`.
 **/
+@:transitive
 @:forward(join, reverse, sort, toString, unShift, insert, remove, iterator)
 abstract Array<T>(StdArray<T>) from StdArray<T> to StdArray<T> {
 	public var length(get, never): UInt;


### PR DESCRIPTION
This is required so that higher level abstracts of this type can be initialised with standard array literal syntax without compiler errors.

For example, in greeter:
https://github.com/fal-works/greeter/blob/master/src/greeter/Parser.hx#L42
```haxe
final parsed: CommandArgumentList = [];
```
This wasn't allowed because it would require a transitive cast (see https://github.com/HaxeFoundation/haxe/pull/9698) from std.Array to Array to CommandArgumentList, which is disabled by default. By enabling transitive casts for this custom Array type we can avoid this error.

Partially addresses: https://github.com/fal-works/hlc-compiler/issues/1